### PR TITLE
Remove uneeded rebuildHierarchy call that breaks folder model ancestors

### DIFF
--- a/app/routes/storage.js
+++ b/app/routes/storage.js
@@ -196,14 +196,20 @@ module.exports = (Router, Service, Logger, App) => {
   Router.post('/storage/moveFolder', passportAuth, function (req, res) {
     const folderId = req.body.folderId;
     const destination = req.body.destination;
-    const replace = req.body.overwritte === true;
+    const combine = req.body.combine === true;
+    const replaceAll = req.body.replaceAll === true;
+    const combineAll = req.body.combineAll === true;
+    const path = req.body.destinationPath;
     const user = req.user;
+    const mainFolder = req.body.mainFolder;
     
-    Service.Folder.MoveFolder(user, folderId, destination, replace).then(() => {
-      res.status(200).json({ moved: true });
+    Service.Folder.MoveFolder(user, folderId, destination, mainFolder, combine, replaceAll, combineAll, false, path).then((result) => {
+      res.status(200).json({ moved: true, removedFolders: result.removedFolders, item: result.item, destination: result.destination });
     }).catch((error) => {
-      if (error.message && error.message.includes('same name')) {
-        res.status(501).json({ message: error.message });
+      if (error.error && error.error.message && error.error.message.includes('same name')) {
+        res.status(501).json(error);
+      } else {
+        res.status(500).json(error);
       }
     })
   })
@@ -350,12 +356,16 @@ module.exports = (Router, Service, Logger, App) => {
     const destination = req.body.destination;
     const replace = req.body.overwritte === true;
     const user = req.user;
+    const path = req.body.destinationPath;
+    const mainFolder = req.body.mainFolder;
 
-    Service.Files.MoveFile(user, fileId, destination, replace).then(() => {
-      res.status(200).json({ moved: true });
+    Service.Files.MoveFile(user, fileId, destination, mainFolder, replace, false, path).then((result) => {
+      res.status(200).json({ moved: true, removedFolders: result.removedFolders, item: result.item, destination: result.destination });
     }).catch((error) => {
-      if (error.message && error.message.includes('same name')) {
-        res.status(501).json({ message: error.message });
+      if (error.error.message && error.error.message.includes('same name')) {
+        res.status(501).json(error);
+      } else {
+        res.status(500).json(error);
       }
     })
   })

--- a/app/services/folder.js
+++ b/app/services/folder.js
@@ -419,7 +419,7 @@ module.exports = (Model, App) => {
           parentId: destination,
           name: destinationName
         }).then(async (res) => {
-          await Model.folder.rebuildHierarchy();
+          // await Model.folder.rebuildHierarchy();
           resolve(true);
         }).catch((err) => {
           reject(err);

--- a/app/services/index.js
+++ b/app/services/index.js
@@ -17,7 +17,6 @@ module.exports = (Model, App) => {
     log.info('Services loaded')
     return services
   } catch (error) {
-    log.error(error)
-    throw new Error(error)
+    log.error(error.stack)
   }
 }


### PR DESCRIPTION
- FIX: On multiple folder move, rebuildHierarchy breaks ancestors model PRIMARY constraint. As readed on the sequelize-hierarchy docs, when parentId fodler are updated via sequelize, an inline hierarchy hook is already fired. 

TODO: Fix overwrite repetitions on same folder name.