### PR TITLE
Improved error shown

### DIFF
--- a/app/services/user.js
+++ b/app/services/user.js
@@ -272,7 +272,7 @@ module.exports = (Model, App) => {
   const UpdatePasswordMnemonic = async (user, currentPassword, newPassword, newSalt, mnemonic, privateKey) => {
     const storedPassword = user.password.toString();
     if (storedPassword !== currentPassword) {
-      throw Error('Invalid password');
+      throw Error('The introduced password doesn\'t match your current password');
     }
 
     await Model.users.update({


### PR DESCRIPTION
When changing the password users are requested to type in their current password, and if they wrongly type it, `Invalid password` is shown. Changed it for a better suitable user friendly error