### PR TITLE
fix/use-same-file-attribute

### DIFF
--- a/src/app/routes/storage.js
+++ b/src/app/routes/storage.js
@@ -5,7 +5,6 @@ const logger = require('../../lib/logger').default;
 const AnalyticsService = require('../../lib/analytics/AnalyticsService');
 const CONSTANTS = require('../constants');
 const { ReferralsNotAvailableError } = require('../services/errors/referrals');
-
 const Logger = logger.getInstance();
 
 const { passportAuth } = passport;
@@ -148,6 +147,18 @@ module.exports = (Router, Service, App) => {
     const { behalfUser } = req;
     const { file } = req.body;
     const internxtClient = req.headers['internxt-client'];
+
+    if (!file.fileId && file.file_id) {
+      // TODO : Remove WHEN every project uses the SDK
+      file.fileId = file.file_id;
+    }
+
+    if (!file || !file.fileId || !file.bucket || !file.size || !file.folder_id || !file.name) {
+      Logger.error(
+        `Invalid metadata trying to create a file for user ${behalfUser.email}: ${JSON.stringify(file, null, 2)}`
+      );
+      throw Error('Invalid metadata for new file');
+    }
 
     const result = await Service.Files.CreateFile(behalfUser, file);
 

--- a/src/app/services/files.js
+++ b/src/app/services/files.js
@@ -2,8 +2,6 @@ const sequelize = require('sequelize');
 const async = require('async');
 const createHttpError = require('http-errors');
 const AesUtil = require('../../lib/AesUtil');
-const { default: Logger } = require('../../lib/logger');
-const logger = Logger.getInstance();
 
 // Filenames that contain "/", "\" or only spaces are invalid
 const invalidName = /[/\\]|^\s*$/;
@@ -12,12 +10,6 @@ const { Op } = sequelize;
 
 module.exports = (Model, App) => {
   const CreateFile = async (user, file) => {
-    // TODO: Move validation to endpoints
-    if (!file || !file.fileId || !file.bucket || !file.size || !file.folder_id || !file.name) {
-      logger.error(`Invalid metadata trying to create a file for user ${user.email}: ${JSON.stringify(file, null, 2)}`);
-      throw Error('Invalid metadata for new file');
-    }
-
     return Model.folder
       .findOne({
         where: {
@@ -48,7 +40,7 @@ module.exports = (Model, App) => {
           type: file.type,
           size: file.size,
           folder_id: folder.id,
-          fileId: file.file_id,
+          fileId: file.fileId,
           bucket: file.bucket,
           encrypt_version: file.encrypt_version,
           userId: user.id,
@@ -56,7 +48,7 @@ module.exports = (Model, App) => {
         };
 
         try {
-          AesUtil.decrypt(file.name, file.file_id);
+          AesUtil.decrypt(file.name, file.fileId);
           fileInfo.encrypt_version = '03-aes';
         } catch {
           // eslint-disable-next-line no-empty


### PR DESCRIPTION
I noticed that on the call to create a file, a specific attribute name was being validated to check its existence, but then another one was being used to create the file. 

I understand it was working because, as far as I could check on the drive-web project, to solve the issue, both attributes were being sent.

Now the SDK will be only be sending one of them. Since I noticed that most of the project uses camelCase, I kept the use of `fileId` and removed `file_id`.