### PR TITLE
fix/centralize-deactivation-email-endpoint

### DIFF
--- a/src/app/routes/activation.ts
+++ b/src/app/routes/activation.ts
@@ -18,14 +18,15 @@ class ActivationController {
 
   async sendDeactivationEmail(req: Request<{ email: string }>, res: Response) {
     const email = req.params.email.toLowerCase();
-    const user = await this.service.User.FindUserByEmail(email);
-    const uuid = user.uuid;
-
-    await this.service.User.deactivate(email);
-
-    res.status(200).send({ error: null, message: 'Email sent' });
-
-    AnalyticsService.trackDeactivationRequest(uuid, req);
+    try {
+      const user = await this.service.User.FindUserByEmail(email);
+      const uuid = user.uuid;
+      await this.service.User.deactivate(email);
+      res.status(200).send({ error: null, message: 'Email sent' });
+      AnalyticsService.trackDeactivationRequest(uuid, req);
+    } catch (error) {
+      res.status(404).send({ error: 'User not found' });
+    }
   }
 
   async deactivate(req: Request, res: Response) {

--- a/src/app/routes/activation.ts
+++ b/src/app/routes/activation.ts
@@ -18,15 +18,12 @@ class ActivationController {
 
   async sendDeactivationEmail(req: Request<{ email: string }>, res: Response) {
     const email = req.params.email.toLowerCase();
-    try {
-      const user = await this.service.User.FindUserByEmail(email);
-      const uuid = user.uuid;
-      await this.service.User.deactivate(email);
-      res.status(200).send({ error: null, message: 'Email sent' });
-      AnalyticsService.trackDeactivationRequest(uuid, req);
-    } catch (error) {
-      res.status(404).send({ error: 'User not found' });
-    }
+    const user = await this.service.User.FindUserByEmail(email);
+    const uuid = user.uuid;
+    await this.service.User.deactivate(email);
+    res.status(200).send({ error: null, message: 'Email sent' });
+    logger.info('User %s requested deactivation', email);
+    AnalyticsService.trackDeactivationRequest(uuid, req);
   }
 
   async deactivate(req: Request, res: Response) {

--- a/src/lib/analytics/AnalyticsService.ts
+++ b/src/lib/analytics/AnalyticsService.ts
@@ -9,11 +9,10 @@ import express from 'express';
 
 const NETWORK_ANALYTICS_THRESHOLD = 6144;
 
-export async function trackDeactivationRequest(req: express.Request & ReqUser) {
+export async function trackDeactivationRequest(uuid: string, req: express.Request) {
   const context = await getContext(req);
-  const userId = req.user.uuid;
   Analytics.track({
-    userId,
+    userId: uuid,
     event: TrackName.DeactivationRequest,
     context,
   });


### PR DESCRIPTION
Right now we have two endpoints that do the same(send the deactivation email), but one of them is tracking the event and the other is not.

Since we are developing the SDK and the function of sending the email is one, no matter where we are coming from(at least by now), I added a new endpoint, public, that does the same that the others do, but using the `email` as a parameter.

In this change I'm not removing the other two endpoints, since we want to keep compatibility with the clients not using the SDK yet. Once everyone goes through it, we can remove the other ones.