### PR TITLE
improve/remove-unnecessary-parameters

### DIFF
--- a/src/app/routes/storage.js
+++ b/src/app/routes/storage.js
@@ -197,11 +197,10 @@ module.exports = (Router, Service, App) => {
   });
 
   Router.post('/storage/move/file', passportAuth, sharedAdapter, (req, res) => {
-    const { fileId, destination, bucketId, relativePath } = req.body;
+    const { fileId, destination } = req.body;
     const { behalfUser: user } = req;
-    const mnemonic = req.headers['internxt-mnemonic'];
 
-    Service.Files.MoveFile(user, fileId, destination, bucketId, mnemonic, relativePath)
+    Service.Files.MoveFile(user, fileId, destination)
       .then((result) => {
         res.status(200).json(result);
       })

--- a/src/app/services/files.js
+++ b/src/app/services/files.js
@@ -199,7 +199,7 @@ module.exports = (Model, App) => {
     ]);
   };
 
-  const MoveFile = async (user, fileId, destination, bucketId, mnemonic, relativePath) => {
+  const MoveFile = async (user, fileId, destination) => {
     const file = await Model.file.findOne({ where: { fileId: { [Op.eq]: fileId } }, userId: user.id });
 
     if (!file) {
@@ -229,7 +229,6 @@ module.exports = (Model, App) => {
     }
 
     // Move
-    await App.services.Inxt.renameFile(user.email, user.userId, mnemonic, bucketId, fileId, relativePath);
     const result = await file.update({
       folder_id: parseInt(destination, 10),
       name: destinationName,
@@ -238,14 +237,13 @@ module.exports = (Model, App) => {
     // we don't want ecrypted name on front
     file.setDataValue('name', App.services.Crypt.decryptName(destinationName, destination));
     file.setDataValue('folder_id', parseInt(destination, 10));
-    const response = {
-      result,
+
+    return {
+      result: result,
       item: file,
       destination,
       moved: true,
     };
-
-    return response;
   };
 
   const isFileOfTeamFolder = (fileId) =>


### PR DESCRIPTION
Now the identifier of a file on the network is a UUID, so we don't need to rehash and update the identifier when the file is moved to another destination. That allows to remove this rename function and not require the extra parameters on the request.