### PR TITLE
fix/remove-parameter-from-endpoint

### DIFF
--- a/src/app/routes/stripe.js
+++ b/src/app/routes/stripe.js
@@ -365,9 +365,7 @@ module.exports = (Router, Service) => {
   });
 
   Router.get('/v3/stripe/products', (req, res) => {
-    const test = req.query.test === 'true';
-
-    Service.Stripe.getAllStorageProducts2(test)
+    Service.Stripe.getAllStorageProducts2()
       .then((products) => {
         res.status(200).send(products);
       })

--- a/src/app/services/stripe.js
+++ b/src/app/services/stripe.js
@@ -167,10 +167,10 @@ module.exports = () => {
 
   /**
    * @description Adds a product for every product.price found
-   * @param {*} isTest
    * @returns
    */
-  const getAllStorageProducts2 = async (isTest = false) => {
+  const getAllStorageProducts2 = async () => {
+    const isTest = process.env.NODE_ENV === 'development';
     const stripe = getStripe(isTest);
     const cacheName = `stripe_plans_v3_${isTest ? 'test' : 'production'}`;
     const cachedPlans = cache.get(cacheName);


### PR DESCRIPTION
This endpoint is receiving a parameter from front that indicates to which environment it has to do the requests.
That is weird, better to use its own environment vars to take this decision until final solution can be implemented.