### PR TITLE
[_]:fix/store-bridge-user-on-teams-admin-creation

### DIFF
--- a/src/app/routes/teams.js
+++ b/src/app/routes/teams.js
@@ -262,6 +262,7 @@ module.exports = (Router, Service, App) => {
           password: encryptedPassword,
           salt: encryptedSalt,
           mnemonic,
+          bridgeUser: team.bridge_user
         };
         const userRegister = await Service.User.FindOrCreate(user);
         await team.update({


### PR DESCRIPTION
- Adds `bridgeUser` field to `user` to create to prevent field to be empty
- Prevents `bridgeUser` to remain null when this field should be set properly