### PR TITLE
fix/folder-tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "scripts": {
     "start": "node ./build/app.js",
+    "debug": "cross-env NODE_ENV=development nodemon --ext 'ts,js' --exec 'node --inspect=0.0.0.0:9202 --require ts-node/register src/app.ts'",
     "dev": "cross-env NODE_ENV=development nodemon --ext 'ts,js' src/app.ts",
     "docker": "cross-env NODE_ENV=docker nodemon app.ts",
     "testsuite": "cross-env APP_SEGMENT_KEY=a NODE_ENV=test ts-mocha tests/**/*.ts",


### PR DESCRIPTION
Currently the tree generation for a folder is failing when there is more than one level of depth on nested folders.

This solved this problem and should also prevent some others.

PS: Also adds an extra command on the package.json to run the project in debug mode

PPS: To be precise. It's not failing, it's just never ending. Tree generation gives timeout.