### PR TITLE
hotfix/storage-recents-limit

### DIFF
--- a/src/app/routes/storage.ts
+++ b/src/app/routes/storage.ts
@@ -429,13 +429,7 @@ export class StorageController {
     const { behalfUser } = req as SharedRequest;
     const { user } = req as PassportRequest;
     const { limit } = req.query;
-
-    if (Validator.isInvalidPositiveNumber(limit)) {
-      throw createHttpError(400, 'Limit is not valid');
-    }
-    let validLimit = Number(limit);
-
-    validLimit = Math.min(validLimit, CONSTANTS.RECENTS_LIMIT) || CONSTANTS.RECENTS_LIMIT;
+    const validLimit = Math.min(parseInt(limit), CONSTANTS.RECENTS_LIMIT) || CONSTANTS.RECENTS_LIMIT;
 
     return this.services.Files.getRecentFiles(behalfUser, validLimit)
       .then((files: FileAttributes[]) => {


### PR DESCRIPTION
- Parse recent limit instead of validating it when could be a string