### PR TITLE
[_]: fix/refer to the development Dockerfile in bridge

### DIFF
--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   bridge:
     build:
       context: ../../bridge
-      dockerfile: Dockerfile
+      dockerfile: infrastructure/development.Dockerfile
     container_name: bridge
     networks:
       - internxt


### PR DESCRIPTION
Previously it was referring to production Dockerfile now referring to development Dockerfile