### PR TITLE
fix: upgrate sql formatter to avoid previous version bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "sequelize": "^6.3.5",
     "socket.io": "^4.2.0",
     "speakeasy": "^2.0.0",
-    "sql-formatter": "^4.0.2",
+    "sql-formatter": "^8.2.0",
     "stripe": "^8.178.0",
     "uuid": "^8.3.2",
     "winston": "^3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4275,10 +4275,10 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sql-formatter@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-4.0.2.tgz#2b359e5a4c611498d327b9659da7329d71724607"
-  integrity sha512-R6u9GJRiXZLr/lDo8p56L+OyyN2QFJPCDnsyEOsbdIpsnDKL8gubYFo7lNR7Zx7hfdWT80SfkoVS0CMaF/DE2w==
+sql-formatter@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-8.2.0.tgz#2b664f02bb6b7bb6fcad1346e850b8f583303469"
+  integrity sha512-5hQOSOk8jfhPkNgUmpm+9Fn2aaLWcf4vKL/dIvUN5q9rsamKHSyN/gL79xpkETNOyL+Zv5BMQfA7z9Rmz/DJJg==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
`FindOrCreate` method on user service was failing due sql-formatter could not parse booleans correctly with postgres. This was causing the register of new users to fail

> Note: I've used the docker-compose with postgres

[Original sql-formatter issue](https://github.com/sql-formatter-org/sql-formatter/issues/129)