### PR TITLE
[_]: Fix/maria specific options

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,8 +1,9 @@
 NODE_ENV=development
-RDS_HOSTNAME=maria
+RDS_HOSTNAME=drive-database
 RDS_DBNAME=xCloud
-RDS_USERNAME=root
+RDS_USERNAME=postgres
 RDS_PASSWORD=example
+RDS_PORT=5432
 STORJ_BRIDGE_HTTPS=http://bridge:6382
 STORJ_BRIDGE=http://bridge:6382
 CAPTCHA_SECRET=6Lf4_xsURABVAMlnlRzIRtzkiOtdklEsvZfZ9JIk

--- a/src/config/initializers/database.ts
+++ b/src/config/initializers/database.ts
@@ -17,12 +17,6 @@ export default class Database {
     const defaultSettings = {
       resetAfterUse: true,
       operatorsAliases: 0,
-      dialectOptions: {
-        connectTimeout: 20000,
-        options: {
-          requestTimeout: 4000,
-        },
-      },
       pool: {
         maxConnections: Number.MAX_SAFE_INTEGER,
         maxIdleTime: 30000,


### PR DESCRIPTION
- Removes `dialectOptions` since they cause an error connecting in postgres.

Unsure if we want to find the equivalent in postgres (which I couldn't find) or we should just discard this config altogether for postgres. I leave Sergio to take that decision.

- Adds ENV variables to .env file that make it compatible to connect to postgres.