### PR TITLE
[_]: fix/create avatars bucket on s3 initalization

### DIFF
--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -94,6 +94,7 @@ services:
       sleep 10;
       /usr/bin/mc config host add myminio http://s3:9000 minioadmin minioadmin;
       /usr/bin/mc mb --ignore-existing myminio/internxt;
+      /usr/bin/mc mb --ignore-existing myminio/avatars;
       /usr/bin/mc policy set public myminio/internxt;
       /usr/bin/mc admin user add myminio internxt internxt;
       /usr/bin/mc admin policy set myminio readwrite user=internxt;


### PR DESCRIPTION
Previously the avatars bucket had to be added manually added. Now it's created alongside the internxt one on the initialize_s3 container