### PR TITLE
[_]: fix/delete folders correctly

### DIFF
--- a/migrations/20220309190600-create-deleted-files-trigger.js
+++ b/migrations/20220309190600-create-deleted-files-trigger.js
@@ -6,7 +6,7 @@ module.exports = {
       $$
       BEGIN
       INSERT INTO deleted_files(file_id, user_id, folder_id, bucket) select file_id, user_id, folder_id, bucket from files where files.folder_id = OLD.id;
-      RETURN NEW;
+      RETURN OLD;
       END;
       $$
       LANGUAGE 'plpgsql';`);


### PR DESCRIPTION
Updated `insert_deleted_files` to return the 'old' value.

Previously the deletion was aborted due the trigger returning the 'new' value which on DELETE triggers is null.

In order to test it you will need a fresh database to run the migrations in to it.