### PR TITLE
[_]: fix/ambiguous id reference retriving backup devices

### DIFF
--- a/src/app/services/backups.js
+++ b/src/app/services/backups.js
@@ -20,7 +20,7 @@ module.exports = (Model, App) => {
     return Model.device.findAll({
       where: { userId },
       attributes: { include: [[fn('SUM', col('backups.size')), 'size']] },
-      group: ['id'],
+      group: [col('device.id'), col('backups.id')],
       include: [{ model: Model.backup, attributes: ['size'] }],
     });
   };


### PR DESCRIPTION
Previously, making a get request to /api/backup/device was returning an internal error code with the following message:
``` json
{
    "error": "column reference \"id\" is ambiguous"
}
```

This was happening because the query executed had a _JOIN_ but only on field (id) on the _GROUP BY_:
``` sql
SELECT "device"."id", ...
FROM "devices" AS "device" 
LEFT OUTER JOIN "backups" AS "backups" ON "device"."id" = "backups"."deviceId" 
WHERE "device"."userId" = 1 
GROUP BY "id";``