### PR TITLE
[_]: feat/parametrize-logger-level

### DIFF
--- a/src/config/environments/development.js
+++ b/src/config/environments/development.js
@@ -24,7 +24,7 @@ exports.data = {
     CRYPTO_SECRET2: process.env.CRYPTO_SECRET2,
   },
   logger: {
-    level: 2,
+    level: 'info',
   },
   STORJ_BRIDGE: 'https://api.internxt.com',
 };

--- a/src/config/environments/staging.js
+++ b/src/config/environments/staging.js
@@ -34,7 +34,7 @@ exports.data = {
     CRYPTO_SECRET2: process.env.CRYPTO_SECRET2,
   },
   logger: {
-    level: 'info',
+    level: 4,
   },
   STORJ_BRIDGE: 'https://api.internxt.com',
 };

--- a/src/config/environments/staging.js
+++ b/src/config/environments/staging.js
@@ -34,7 +34,7 @@ exports.data = {
     CRYPTO_SECRET2: process.env.CRYPTO_SECRET2,
   },
   logger: {
-    level: 4,
+    level: 'info',
   },
   STORJ_BRIDGE: 'https://api.internxt.com',
 };

--- a/src/config/environments/test.js
+++ b/src/config/environments/test.js
@@ -17,7 +17,7 @@ exports.data = {
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
   },
   logger: {
-    level: 0,
+    level: 'emerg',
   },
   STORJ_BRIDGE: 'http://localhost:6382',
 };

--- a/src/config/initializers/server.ts
+++ b/src/config/initializers/server.ts
@@ -30,7 +30,7 @@ export default class Server {
 
   constructor() {
     this.config = Config.getInstance();
-    this.logger = Logger.getInstance();
+    this.logger = Logger.getInstance(this.config.get('logger'));
     this.express = express();
     this.router = express.Router();
     this.instance = null;

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -42,18 +42,22 @@ const winstonDevOptions: winston.LoggerOptions = {
   transports: [new winston.transports.Console()],
 };
 
+type LoggerConfig = {
+  level: string;
+}
+
 export default class Logger {
   private static instance: winston.Logger;
 
-  static getInstance(): winston.Logger {
+  static getInstance(config?: LoggerConfig): winston.Logger {
     if (!Logger.instance) {
-      Logger.instance = loggerInstance();
+      Logger.instance = loggerInstance(config);
     }
 
     return Logger.instance;
   }
 }
 
-const loggerInstance = (): winston.Logger => {
-  return winston.createLogger(isProduction() ? winstonProdOptions : winstonDevOptions);
+const loggerInstance = (config?: LoggerConfig): winston.Logger => {
+  return winston.createLogger(isProduction() ? winstonProdOptions : {...winstonDevOptions, ...config});
 };


### PR DESCRIPTION
Previously the logger info on the config files was unused. Now if they are present and the environment is not production the "default" development configuration will be overrided by the config