### PR TITLE
[_]: fix/ postgres procedure had no destination for result data

### DIFF
--- a/migrations/20220309190601-create-clear_orphan_folders_by_user-procedure.js
+++ b/migrations/20220309190601-create-clear_orphan_folders_by_user-procedure.js
@@ -2,12 +2,13 @@ module.exports = {
   up: async (queryInterface) => {
     await queryInterface.sequelize.query(
       `
-      CREATE OR REPLACE PROCEDURE clear_orphan_folders_by_user(userid int)
+      CREATE OR REPLACE PROCEDURE clear_orphan_folders_by_user(IN userid int, OUT total_left integer)
       LANGUAGE 'plpgsql'
       AS $$
       BEGIN
         delete from folders where parent_id is not null and parent_id not in (select id from folders where user_id = userid) and user_id = userid;
-        select count(*) as total_left from folders where parent_id is not null and parent_id not in (select id from folders where user_id = userid) and user_id = userid;
+        select count(*) from folders where parent_id is not null and parent_id not in (select id from folders where user_id = userid) and user_id = userid
+        into total_left;
       END;$$
       `,
     );

--- a/src/app/services/folder.js
+++ b/src/app/services/folder.js
@@ -94,8 +94,9 @@ module.exports = (Model, App) => {
 
   // Requires stored procedure
   const DeleteOrphanFolders = async (userId) => {
-    const clear = await App.database.query('CALL clear_orphan_folders_by_user (:userId)', { replacements: { userId } });
-
+    const clear = await App.database.query('CALL clear_orphan_folders_by_user (:userId, :output)', {
+      replacements: { userId, output: null },
+    });
     const totalLeft = clear[0].total_left;
 
     if (totalLeft > 0) {


### PR DESCRIPTION
On postgres the `clear_orphan_folders_by_user` procedure failed due `query has no destination for result data`. Leaving the leaving folders without a valid parent_id