### PR TITLE
[_]: fix/ return more specific http status

### DIFF
--- a/src/app/routes/storage.ts
+++ b/src/app/routes/storage.ts
@@ -11,6 +11,7 @@ import teamsMiddlewareBuilder from '../middleware/teams';
 import Validator from '../../lib/Validator';
 import { FileAttributes } from '../models/file';
 import CONSTANTS from '../constants';
+import { HttpError } from 'http-errors';
 
 interface Services {
   Files: any;
@@ -321,6 +322,11 @@ export class StorageController {
       })
       .catch((err: Error) => {
         this.logger.error(err);
+        if(err instanceof HttpError) {
+          res.status(err.status).json({
+            error: err.message,
+          });
+        }
         res.status(500).json({
           error: err.message,
         });


### PR DESCRIPTION
Currently when a file is tried to being moved and from some reason fails always returns a 500 Internal Error. But its possible that the error thrown was a `HttpError` with a _custom_ http status. Like in there https://github.com/internxt/drive-server/blob/1f1928119f01cefd23f5709e20d5b3b693db040a/src/app/services/files.js#L228

