### PR TITLE
[_]: Fix/ avoid race conditions on keyserver creation

### DIFF
--- a/src/app/services/user.js
+++ b/src/app/services/user.js
@@ -80,7 +80,7 @@ module.exports = (Model, App) => {
 
       if (isNewRecord) {
         if (user.publicKey && user.privateKey && user.revocationKey) {
-          Model.keyserver.findOrCreate({
+          await Model.keyserver.findOrCreate({
             where: { user_id: userResult.id },
             defaults: {
               user_id: user.id,


### PR DESCRIPTION
If an error occurs before the _keyserver_ is found or created the transaction gets roll-backed, making it unavailable for the _keyserver_ model. Throwing an error similar to:
`rollback has been called on this transaction(9055cfcd-0249-574d-8b6e-b60ca35c7952), you can no longer use it. (....)`