### PR TITLE
fix: hadle find user by email promise rejection on access

### DIFF
--- a/src/app/routes/auth.ts
+++ b/src/app/routes/auth.ts
@@ -5,6 +5,8 @@ import { UserAttributes } from '../models/user';
 import { passportAuth, Sign } from '../middleware/passport';
 import Config from '../../config/config';
 import { AuthorizedUser } from './types';
+import Logger from '../../lib/logger';
+import winston from 'winston';
 
 interface Services {
   User: any;
@@ -20,10 +22,12 @@ interface Services {
 export class AuthController {
   private service: Services;
   private config: Config;
+  private logger: winston.Logger;
 
   constructor(service: Services, config: Config) {
     this.service = service;
     this.config = config;
+    this.logger = Logger.getInstance();
   }
 
   async register(req: Request<{ email: string }>, res: Response) {
@@ -68,6 +72,7 @@ export class AuthController {
     const MAX_LOGIN_FAIL_ATTEMPTS = 10;
 
     const userData: any = await this.service.User.FindUserByEmail(req.body.email).catch(() => {
+      this.logger.info('Attempted login with a non-existing email: %s', req.body.email);
       throw createHttpError(401, 'Wrong email/password');
     });
 

--- a/src/app/routes/auth.ts
+++ b/src/app/routes/auth.ts
@@ -67,7 +67,9 @@ export class AuthController {
   async access(req: Request, res: Response) {
     const MAX_LOGIN_FAIL_ATTEMPTS = 10;
 
-    const userData: any = await this.service.User.FindUserByEmail(req.body.email);
+    const userData: any = await this.service.User.FindUserByEmail(req.body.email).catch(() => {
+      // eslint-disable @typescript-eslint/no-empty-function
+    });
 
     if (!userData) {
       throw createHttpError(401, 'Wrong email/password');

--- a/src/app/routes/auth.ts
+++ b/src/app/routes/auth.ts
@@ -68,12 +68,8 @@ export class AuthController {
     const MAX_LOGIN_FAIL_ATTEMPTS = 10;
 
     const userData: any = await this.service.User.FindUserByEmail(req.body.email).catch(() => {
-      // eslint-disable @typescript-eslint/no-empty-function
-    });
-
-    if (!userData) {
       throw createHttpError(401, 'Wrong email/password');
-    }
+    });
 
     const loginAttemptsLimitReached = userData.errorLoginCount >= MAX_LOGIN_FAIL_ATTEMPTS;
 
@@ -192,8 +188,7 @@ export class AuthController {
   }
 
   async areCredentialsCorrect(req: Request, res: Response) {
-    if (!req.query.hashedPassword)
-      throw createHttpError(400, 'Query params must contain the hashedPassword property');
+    if (!req.query.hashedPassword) throw createHttpError(400, 'Query params must contain the hashedPassword property');
 
     const { hashedPassword } = req.query;
     const email = (req as AuthorizedUser).user.email;


### PR DESCRIPTION
Catch `FindUserByEmail` promise rejection to properly handle don't find the user email.

The FindUserByEmail function https://github.com/internxt/drive-server/blob/539238d265e0c010d07ab818ff34c21402f2120a/src/app/services/user.js#L174-L193