### PR TITLE
[_] fix: Rename rds_hostname on .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,5 @@
 NODE_ENV=development
-RDS_HOSTNAME=drive-database
+RDS_HOSTNAME=postgres
 RDS_DBNAME=xCloud
 RDS_USERNAME=postgres
 RDS_PASSWORD=example


### PR DESCRIPTION
Fixed .env.template by renaming RDS_HOSTNAME from 'drive-database' to 'postgres'