### PR TITLE
[WT-44] fix: enable auto pipelining on ioredis

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "helmet": "^4.1.1",
     "http-errors": "^1.8.0",
     "inxt-service-mailer": "internxt/mailer",
-    "ioredis": "^4.28.0",
+    "ioredis": "^4.28.2",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.15",
     "mariadb": "^2.5.2",

--- a/src/app/services/folder.js
+++ b/src/app/services/folder.js
@@ -541,7 +541,7 @@ module.exports = (Model, App) => {
 
     const res = await redis.acquireOrRefreshLock(`${userId}-${folderId}`, lockId);
 
-    if (!res) throw new Error();
+    if (!res) throw new Error(`Unable to obtain lock for ${userId}`);
   };
 
   const getUserDirectoryFiles = async (userId, directoryId, offset, limit) => {

--- a/src/config/initializers/redis.ts
+++ b/src/config/initializers/redis.ts
@@ -12,6 +12,7 @@ export default class Redis {
     const config = {
       host: process.env.REDIS_HOST,
       password: process.env.REDIS_PASSWORD,
+      enableAutoPipelining: true
     };
 
     Redis.instance = new IORedis(config);


### PR DESCRIPTION
Enable auto pipelining on ioredis to try reduce the latency

> …In order to meet this requirement, the strategy to talk with the N Redis servers to reduce latency is definitely multiplexing (putting the socket in non-blocking mode, send all the commands, and read all the commands later, assuming that the RTT between the client and each instance is similar).

https://redis.io/docs/reference/patterns/distributed-locks/#performance-crash-recovery-and-fsync

Also update ioredis for a fix on autopipeling

https://github.com/luin/ioredis/blob/v4/Changelog.md#4282-2021-12-01