### PR TITLE
[_] fix: return file size as number

### DIFF
--- a/src/app/services/folder.js
+++ b/src/app/services/folder.js
@@ -258,7 +258,7 @@ module.exports = (Model, App) => {
     const foldersId = folders.map((result) => result.id);
     const files = await Model.file.findAll({
       where: { folder_id: { [Op.in]: foldersId }, userId: userObject.id },
-    });
+    }).then(files => files.map(file => ({...file, size: parseInt(file.size)})));
     return {
       folders,
       files,


### PR DESCRIPTION
`BIGINT` numbers get converted to string to avoid loss value: https://github.com/sequelize/sequelize/issues/7377#issuecomment-286854849

This was making drive-desktop to never be in sync.

Output of drive-desktop, note that the size is the same but the remote one is a string
![imatge](https://user-images.githubusercontent.com/38570230/189128792-8d1c2446-87c9-4199-bb38-6bb1b7433bb8.png)
