### PR TITLE
[_]:test/add-desktop-test

### DIFF
--- a/tests/e2e/e2e-spec.ts
+++ b/tests/e2e/e2e-spec.ts
@@ -980,6 +980,29 @@ describe('E2E TEST', () => {
       expect(file).toHaveProperty('folderId');
     });
 
+    it('should return all the info from a folder', async () => {
+      const { body: folder } = await createFolder(
+        {
+          folderName: 'folderOnRoot',
+          parentFolderId: rootFolderId,
+        },
+        token,
+      );
+
+      const response = await request(app).get('/api/desktop/list/0').set('Authorization', `Bearer ${token}`);
+
+      const result = response.body.folders[0];
+
+      expect(result.id).toBe(folder.id);
+
+      expect(result).toHaveProperty('id');
+      expect(result).toHaveProperty('parent_id');
+      expect(result).toHaveProperty('name');
+      expect(result).toHaveProperty('bucket');
+      expect(result).toHaveProperty('updated_at');
+      expect(result).toHaveProperty('created_at');
+    });
+
     it('should return the folders and files of a user', async () => {
       const fileName = encryptFilename(`test-${Date.now()}`, rootFolderId);
       const { body: fileOnRoot } = await createFileOnFolder(rootFolderId, fileName, token);

--- a/tests/e2e/e2e-spec.ts
+++ b/tests/e2e/e2e-spec.ts
@@ -964,22 +964,24 @@ describe('E2E TEST', () => {
 
       const response = await request(app).get('/api/desktop/list/0').set('Authorization', `Bearer ${token}`);
 
-      expect(response.body.files[0]).toHaveProperty('id');
-      expect(response.body.files[0]).toHaveProperty('created_at');
-      expect(response.body.files[0]).toHaveProperty('fileId');
-      expect(response.body.files[0]).toHaveProperty('name');
-      expect(response.body.files[0]).toHaveProperty('type');
-      expect(response.body.files[0]).toHaveProperty('size');
-      expect(response.body.files[0]).toHaveProperty('bucket');
-      expect(response.body.files[0]).toHaveProperty('folder_id');
-      expect(response.body.files[0]).toHaveProperty('encrypt_version');
-      expect(response.body.files[0]).toHaveProperty('deleted');
-      expect(response.body.files[0]).toHaveProperty('deletedAt');
-      expect(response.body.files[0]).toHaveProperty('userId');
-      expect(response.body.files[0]).toHaveProperty('modificationTime');
-      expect(response.body.files[0]).toHaveProperty('createdAt');
-      expect(response.body.files[0]).toHaveProperty('updatedAt');
-      expect(response.body.files[0]).toHaveProperty('folderId');
+      const file = response.body.files[0];
+
+      expect(file).toHaveProperty('id');
+      expect(file).toHaveProperty('created_at');
+      expect(file).toHaveProperty('fileId');
+      expect(file).toHaveProperty('name');
+      expect(file).toHaveProperty('type');
+      expect(file).toHaveProperty('size');
+      expect(file).toHaveProperty('bucket');
+      expect(file).toHaveProperty('folder_id');
+      expect(file).toHaveProperty('encrypt_version');
+      expect(file).toHaveProperty('deleted');
+      expect(file).toHaveProperty('deletedAt');
+      expect(file).toHaveProperty('userId');
+      expect(file).toHaveProperty('modificationTime');
+      expect(file).toHaveProperty('createdAt');
+      expect(file).toHaveProperty('updatedAt');
+      expect(file).toHaveProperty('folderId');
     });
 
     it('should return the folders and files of a user', async () => {


### PR DESCRIPTION
### Adds test to `desktop/list` endpoint:
The endpoint must return the _remote_ files with their properties. Not doing so, the desktop app thinks that the files were deleted on _remote_ and deletes it from the _local_ machine of the user. As happened with https://github.com/internxt/drive-server/pull/291

Currently for a file returns:
- id
- created_at
- fileId
- name
- type
- size
- bucket
- folder_id
- encrypt_version
- deleted
- deletedAt
- userId
- modificationTime
- createdAt
- updatedAt
- folderId

Note that the `folder id` appears twice as `folderId` and `folder_id`. Same with `created at`, appears as `created_at` and `createdAt`. 

Also:
- moved helpers method to general e2e description
