### PR TITLE
[_]: fix/register-account-already-exists

### DIFF
--- a/src/app/services/user.js
+++ b/src/app/services/user.js
@@ -431,7 +431,7 @@ module.exports = (Model, App) => {
     }
 
     if (!userData.isNewRecord) {
-      throw Error('This account already exists');
+      throw createHttpError(409, 'This account already exists');
     }
 
     if (hasReferrer) {


### PR DESCRIPTION
- Register returns account already exists instead of returning an internal server error