### PR TITLE
[_] chore: update env template with redis host

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -33,3 +33,4 @@ STORJ_BRIDGE_HTTPS=http://bridge:6382
 STORJ_BRIDGE=http://bridge:6382
 STRIPE_SK=sk_test_F3Ny2VGUnPga9FtyXkl7mzPc
 STRIPE_SK_TEST=sk_test_R3Ny2VG7nPgeJFrtXdt8mrPc
+REDIS_HOST=redis


### PR DESCRIPTION
Added `REDIS_HOST` variable to the template file. Needed to obtain and release locks on the desktop app.

ℹ️ The `REDIS_PASSWORD` is not needed with the current Redis config.