### PR TITLE
[WT-225] bugfix/Add files and folders downlodad using blob in firefox

### DIFF
--- a/src/app/services/folder.js
+++ b/src/app/services/folder.js
@@ -227,20 +227,20 @@ module.exports = (Model, App) => {
         folder_id: {
           [Op.eq]: folderId,
         },
-        include: [
-          {
-            model: Model.thumbnail,
-            as: 'thumbnails',
-            required: false,
-          },
-          {
-            model: Model.shares,
-            attributes: ['id', 'active', 'hashed_password', 'token', 'code', 'is_folder'],
-            as: 'shares',
-            required: false,
-          },
-        ],
       },
+      include: [
+        {
+          model: Model.thumbnail,
+          as: 'thumbnails',
+          required: false,
+        },
+        {
+          model: Model.shares,
+          attributes: ['id', 'active', 'hashed_password', 'token', 'code', 'is_folder'],
+          as: 'shares',
+          required: false,
+        },
+      ],
     });
   };
 
@@ -325,16 +325,18 @@ module.exports = (Model, App) => {
   };
 
   const isFolderOfTeam = (folderId) => {
-    return Model.folder.findOne({
-      where: {
-        id: { [Op.eq]: folderId },
-      },
-    }).then((folder) => {
-      if (!folder) {
-        throw Error('Folder not found on database, please refresh');
-      }
-      return folder;
-    });
+    return Model.folder
+      .findOne({
+        where: {
+          id: { [Op.eq]: folderId },
+        },
+      })
+      .then((folder) => {
+        if (!folder) {
+          throw Error('Folder not found on database, please refresh');
+        }
+        return folder;
+      });
   };
 
   const UpdateMetadata = (user, folderId, metadata) => {
@@ -357,12 +359,13 @@ module.exports = (Model, App) => {
       },
       (next) => {
         // Get the target folder from database
-        Model.folder.findOne({
-          where: {
-            id: { [Op.eq]: folderId },
-            user_id: { [Op.eq]: user.id },
-          },
-        })
+        Model.folder
+          .findOne({
+            where: {
+              id: { [Op.eq]: folderId },
+              user_id: { [Op.eq]: user.id },
+            },
+          })
           .then((result) => {
             if (!result) {
               throw Error('Folder does not exists');
@@ -376,13 +379,14 @@ module.exports = (Model, App) => {
         if (metadata.itemName) {
           const cryptoFolderName = App.services.Crypt.encryptName(metadata.itemName, folder.parentId);
 
-          Model.folder.findOne({
-            where: {
-              parentId: { [Op.eq]: folder.parentId },
-              name: { [Op.eq]: cryptoFolderName },
-              deleted: { [Op.eq]: false },
-            },
-          })
+          Model.folder
+            .findOne({
+              where: {
+                parentId: { [Op.eq]: folder.parentId },
+                name: { [Op.eq]: cryptoFolderName },
+                deleted: { [Op.eq]: false },
+              },
+            })
             .then((isDuplicated) => {
               if (isDuplicated) {
                 return next(Error('Folder with this name exists'));

--- a/src/app/services/folder.js
+++ b/src/app/services/folder.js
@@ -325,18 +325,16 @@ module.exports = (Model, App) => {
   };
 
   const isFolderOfTeam = (folderId) => {
-    return Model.folder
-      .findOne({
-        where: {
-          id: { [Op.eq]: folderId },
-        },
-      })
-      .then((folder) => {
-        if (!folder) {
-          throw Error('Folder not found on database, please refresh');
-        }
-        return folder;
-      });
+    return Model.folder.findOne({
+      where: {
+        id: { [Op.eq]: folderId },
+      },
+    }).then((folder) => {
+      if (!folder) {
+        throw Error('Folder not found on database, please refresh');
+      }
+      return folder;
+    });
   };
 
   const UpdateMetadata = (user, folderId, metadata) => {
@@ -359,13 +357,12 @@ module.exports = (Model, App) => {
       },
       (next) => {
         // Get the target folder from database
-        Model.folder
-          .findOne({
-            where: {
-              id: { [Op.eq]: folderId },
-              user_id: { [Op.eq]: user.id },
-            },
-          })
+        Model.folder.findOne({
+          where: {
+            id: { [Op.eq]: folderId },
+            user_id: { [Op.eq]: user.id },
+          },
+        })
           .then((result) => {
             if (!result) {
               throw Error('Folder does not exists');
@@ -379,14 +376,13 @@ module.exports = (Model, App) => {
         if (metadata.itemName) {
           const cryptoFolderName = App.services.Crypt.encryptName(metadata.itemName, folder.parentId);
 
-          Model.folder
-            .findOne({
-              where: {
-                parentId: { [Op.eq]: folder.parentId },
-                name: { [Op.eq]: cryptoFolderName },
-                deleted: { [Op.eq]: false },
-              },
-            })
+          Model.folder.findOne({
+            where: {
+              parentId: { [Op.eq]: folder.parentId },
+              name: { [Op.eq]: cryptoFolderName },
+              deleted: { [Op.eq]: false },
+            },
+          })
             .then((isDuplicated) => {
               if (isDuplicated) {
                 return next(Error('Folder with this name exists'));


### PR DESCRIPTION
- Fixed 500 error when call `'/storage/tree/:folderId'` endpoint correcting the way that `include` param was set.  
   - In the function `getFilesByFolderId`, the `include` param was added inside of `where` param in `Model.file.findAll` function, but it has to go at same level. This fixes a crash that happens when`getFilesByFolderId` is executed when calling the above-mentioned enpoint because the wrong addition of `include` param.
   - Code lines affected → 230 to 242
   - Documentation: 
      - [Sequelize findAll ](https://sequelize.org/api/v6/class/src/model.js~model#static-method-findAll)

Warning! ⚠️ 
 - It is necessary to merge this PR before [the related one](https://github.com/internxt/drive-web/pull/510)
 
 Related PRs
  - https://github.com/internxt/drive-web/pull/510