### PR TITLE
[WT-209] fix: logger does not support string building

### DIFF
--- a/src/app/routes/auth.ts
+++ b/src/app/routes/auth.ts
@@ -105,14 +105,14 @@ export class AuthController {
 
   private logReferralError(userId: unknown, err: Error) {
     if (!err.message) {
-      return this.logger.error('[STORAGE]: ERROR message undefined applying referral for user %s', userId);
+      return this.logger.error(`[STORAGE]: ERROR message undefined applying referral for user ${userId}`);
     }
 
     if (err instanceof ReferralsNotAvailableError) {
       return;
     }
 
-    return this.logger.error('[STORAGE]: ERROR applying referral for user %s: %s', userId, err.message);
+    return this.logger.error(`[STORAGE]: ERROR applying referral for user ${userId}: ${err.message}`);
   }
 
   async access(req: Request, res: Response) {


### PR DESCRIPTION
The logger does not support string building, resulting into logs like this one:
```JSON
{
    "hostname": "drive-server-59fbc45696-85nd2",
    "requestId": "0",
    "timestamp": "2022-11-29 09:31:05",
    "level": "error",
    "message": "[STORAGE]: ERROR applying referral for user %s: %s",
    "meta": {}
}
```