### PR TITLE
[WT-247] fix: return timeout when the database timeouts

### DIFF
--- a/src/app/routes/storage.ts
+++ b/src/app/routes/storage.ts
@@ -11,6 +11,7 @@ import Validator from '../../lib/Validator';
 import { FileAttributes } from '../models/file';
 import CONSTANTS from '../constants';
 import { LockNotAvaliableError } from '../services/errors/locks';
+import { ConnectionTimedOutError } from 'sequelize';
 
 type AuthorizedRequest = Request & { user: UserAttributes };
 interface Services {
@@ -291,6 +292,10 @@ export class StorageController {
         }
 
         this.logger.error(`Error getting folder contents, folderId: ${id}: ${err}. Stack: ${err.stack}`);
+
+        if (err instanceof ConnectionTimedOutError) {
+          return res.status(504).send();
+        }
 
         res.status(500).send();
       });


### PR DESCRIPTION
Noticed on the desktop app that some requests are failing. On the log found that could be because of a timeout.

Changes:
/storage/v2/folder/:id/ returns an [504 Gateway Timeout](https://developer.mozilla.org/es/docs/Web/HTTP/Status/504) if that is the case