### PR TITLE
[DR-727] Fix: filter listing by deleted

### DIFF
--- a/src/app/routes/desktop.js
+++ b/src/app/routes/desktop.js
@@ -15,11 +15,13 @@ module.exports = (Router, Service) => {
   Router.get('/desktop/list/:index', passportAuth, (req, res) => {
     const { user } = req;
     const index = parseInt(req.params.index, 10);
+    const deleted = req.query?.trash === 'true';
+
     if (Number.isNaN(index)) {
       return res.status(400).send({ error: 'Bad Index' });
     }
 
-    return Service.Folder.GetFoldersPagination(user, index)
+    return Service.Folder.GetFoldersPagination(user, index, { deleted })
       .then((result) => {
         res.status(200).send(result);
       })

--- a/src/app/services/folder.js
+++ b/src/app/services/folder.js
@@ -270,7 +270,7 @@ module.exports = (Model, App) => {
       });
   };
 
-  const GetFoldersPagination = async (user, index) => {
+  const GetFoldersPagination = async (user, index, filterOptions) => {
     let userObject = user.get({ plain: true });
 
     const isSharedWorkspace = user.bridgeUser !== user.email;
@@ -295,7 +295,7 @@ module.exports = (Model, App) => {
       throw new Error('root folder does not exists');
     }
     const folders = await Model.folder.findAll({
-      where: { user_id: { [Op.eq]: userObject.id } },
+      where: { user_id: { [Op.eq]: userObject.id }, deleted: filterOptions.deleted || false },
       attributes: ['id', 'parent_id', 'name', 'bucket', 'updated_at', 'created_at'],
       order: [['id', 'DESC']],
       limit: 5000,


### PR DESCRIPTION
The method GetFoldersPagination was not filtering by `deleted`. Added the filter option as a param.

This makes that desktop app tries to sync folders and files from the trash