### PR TITLE
[_] fix: don't list root trashed files

### DIFF
--- a/src/app/services/folder.js
+++ b/src/app/services/folder.js
@@ -309,7 +309,7 @@ module.exports = (Model, App) => {
     });
     const foldersId = folders.map((result) => result.id);
     const files = await Model.file.findAll({
-      where: { folder_id: { [Op.in]: foldersId }, userId: userObject.id },
+      where: { folder_id: { [Op.in]: foldersId }, userId: userObject.id, deleted: filterOptions.deleted || false },
       include: [
         {
           model: Model.thumbnail,


### PR DESCRIPTION
Root trashed files were still retrieved

When drive-desktop is notified that there are changes on the remote simply tries to sync