### PR TITLE
[_]: fix/check-if-parent-folder-exists-before-creating-folder

### DIFF
--- a/src/app/routes/storage.ts
+++ b/src/app/routes/storage.ts
@@ -83,12 +83,16 @@ export class StorageController {
     }
 
     if (!parentFolderId || parentFolderId <= 0) {
-      throw createHttpError(400, 'Parent folder ID is not valid');
+      throw createHttpError(400, 'Invalid parent folder id');
     }
 
     const clientId = String(req.headers['internxt-client-id']);
 
     const parentFolder = await this.services.Folder.getById(parentFolderId);
+
+    if (!parentFolder) {
+      throw createHttpError(400, 'Parent folder does not exist');
+    }
 
     if (parentFolder.userId !== user.id) {
       throw createHttpError(403, 'Parent folder does not belong to user');

--- a/src/app/services/folder.js
+++ b/src/app/services/folder.js
@@ -19,6 +19,10 @@ module.exports = (Model, App) => {
         raw: true,
       })
       .then((folder) => {
+        if (!folder) {
+          return null;
+        }
+
         folder.name = App.services.Crypt.decryptName(folder.name, folder.parentId);
 
         return folder;

--- a/src/app/services/folder.js
+++ b/src/app/services/folder.js
@@ -265,20 +265,20 @@ module.exports = (Model, App) => {
         },
         deleted,
       },
-        include: [
-          {
-            model: Model.thumbnail,
-            as: 'thumbnails',
-            required: false,
-          },
-          {
-            model: Model.shares,
-            attributes: ['id', 'active', 'hashed_password', 'token', 'code', 'is_folder'],
-            as: 'shares',
-            required: false,
-          },
-        ],
-      });
+      include: [
+        {
+          model: Model.thumbnail,
+          as: 'thumbnails',
+          required: false,
+        },
+        {
+          model: Model.shares,
+          attributes: ['id', 'active', 'hashed_password', 'token', 'code', 'is_folder'],
+          as: 'shares',
+          required: false,
+        },
+      ],
+    });
   };
 
   const GetFoldersPagination = async (user, index, filterOptions) => {
@@ -336,8 +336,8 @@ module.exports = (Model, App) => {
   };
 
   const GetFoldersPaginationWithoutSharesNorThumbnails = async (
-    user, 
-    index, 
+    user,
+    index,
     filterOptions
   ) => {
     let userObject = user.get({ plain: true });
@@ -364,10 +364,10 @@ module.exports = (Model, App) => {
 
     const foldersId = folders.map((result) => result.id);
     const files = await Model.file.findAll({
-      where: { 
-        folder_id: { [Op.in]: foldersId }, 
-        userId: userObject.id, 
-        deleted: filterOptions.deleted || false 
+      where: {
+        folder_id: { [Op.in]: foldersId },
+        userId: userObject.id,
+        deleted: filterOptions.deleted || false
       },
     });
 


### PR DESCRIPTION
Introduced changes:
- Check if the folder exists explicitly to avoid trying to decrypt a name of an object that is null. 
- Return 400 if the `parentFolderId` does not exist on folder creation.