### PR TITLE
fix(cd): use-node-std-instead-of-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM mhart/alpine-node:14
+FROM node:14
 LABEL author="internxt"
 
 WORKDIR /drive-server
 
 # Add useful packages
-RUN apk add git curl
+# RUN apk add git curl
 
 COPY . .
 
@@ -12,7 +12,7 @@ COPY . .
 RUN yarn && yarn build && yarn --production && yarn cache clean
 
 # Create prometheus directories
-RUN mkdir -p /mnt/prometheusvol{1,2}
+# RUN mkdir -p /mnt/prometheusvol{1,2}
 
 # Start server
 CMD node /drive-server/build/app.js


### PR DESCRIPTION
These changes aim to solve DNS issues between Alpine Docker images and Kubernetes 1.25. References:
- https://github.com/k3s-io/k3s/issues/6132

The related issues are almost timeouts at the time of asking for domain resolutions to the DNS, in this case, `core-dns`.