### PR TITLE
[_]: Fix minio user policy init

### DIFF
--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -101,9 +101,9 @@ services:
       /usr/bin/mc config host add myminio http://s3:9000 minioadmin minioadmin;
       /usr/bin/mc mb --ignore-existing myminio/internxt;
       /usr/bin/mc mb --ignore-existing myminio/avatars;
-      /usr/bin/mc policy set public myminio/internxt;
+      /usr/bin/mc policy attach public myminio/internxt;
       /usr/bin/mc admin user add myminio internxt internxt;
-      /usr/bin/mc admin policy set myminio readwrite user=internxt;
+      /usr/bin/mc admin policy attach myminio readwrite --user internxt;
       exit 0;
       "
     networks:


### PR DESCRIPTION
In recent minio versions some policy commands are deprecated, this causes forbidden access errors when starting the s3 storage in the infra since the user is not being created correctly on minio, leading to upload file errors.

Deprecation docs can be found here:
https://min.io/docs/minio/linux/reference/minio-mc-admin/mc-admin-policy.html