### PR TITLE
[PB-554]: bugfix/Folder download not working correctly in Firefox browser

### DIFF
--- a/src/app/routes/storage.ts
+++ b/src/app/routes/storage.ts
@@ -151,10 +151,9 @@ export class StorageController {
 
     return this.services.Folder.GetTree(user, folderId)
       .then((result: unknown) => {
-        const treeSize = this.services.Folder.GetTreeSize(result);
         res.status(200).send({
           tree: result,
-          size: treeSize,
+          size: 0,
         });
       })
       .catch((err: Error) => {


### PR DESCRIPTION
- Removed use of GetTreeSize function that not exists

⚠️ Merge first drive-web [PR](https://github.com/internxt/drive-web/pull/707)