### PR TITLE
[_] chore: change node version from 14 to 16 to avoid incompatibility with a dependency

### DIFF
--- a/infrastructure/development.Dockerfile
+++ b/infrastructure/development.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:16
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
Now when we were trying to run our development environment we were getting the following error:

![image](https://github.com/internxt/drive-server/assets/117672238/d60f32b7-1f99-4634-8e6b-24e3a2212d35)

this PR includes the update of the file infrastructure/development.Dockerfile to work with node version 16.