### PR TITLE
[PB-759] Feat: allow to create empty files

### DIFF
--- a/src/app/services/files.js
+++ b/src/app/services/files.js
@@ -55,7 +55,7 @@ module.exports = (Model, App) => {
       bucket: file.bucket,
       encrypt_version: file.encrypt_version,
       userId: user.id,
-      uuid: v4(),
+      uuid: file.uuid || v4(),
       folderUuid: folder.uuid,
       modificationTime: file.modificationTime || new Date(),
     };


### PR DESCRIPTION
Allows to create empty files (with no fileId) when the size is 0.

Also allows the clients to specify the Uuid value