### PR TITLE
[PB-813] fix: return http code 409 when trying to rename a file with an exists

### DIFF
--- a/src/app/routes/storage.ts
+++ b/src/app/routes/storage.ts
@@ -12,6 +12,7 @@ import { FileAttributes } from '../models/file';
 import CONSTANTS from '../constants';
 import { LockNotAvaliableError } from '../services/errors/locks';
 import { ConnectionTimedOutError } from 'sequelize';
+import { FileWithNameAlreadyExistsError } from '../services/errors/FileWithNameAlreadyExistsError';
 
 type AuthorizedRequest = Request & { user: UserAttributes };
 interface Services {
@@ -49,7 +50,15 @@ export class StorageController {
       file.fileId = file.file_id;
     }
 
-    if (!file || !file.fileId || !file.bucket || file.size === undefined || file.size === null || !file.folder_id || !file.name) {
+    if (
+      !file ||
+      !file.fileId ||
+      !file.bucket ||
+      file.size === undefined ||
+      file.size === null ||
+      !file.folder_id ||
+      !file.name
+    ) {
       this.logger.error(
         `Invalid metadata trying to create a file for user ${behalfUser.email}: ${JSON.stringify(file, null, 2)}`,
       );
@@ -76,9 +85,7 @@ export class StorageController {
       );
     } catch (err) {
       this.logger.error(
-        `[FILE/CREATE] ERROR: ${(err as Error).message}, BODY ${JSON.stringify(
-          file,
-        )}, STACK: ${(err as Error).stack}`,
+        `[FILE/CREATE] ERROR: ${(err as Error).message}, BODY ${JSON.stringify(file)}, STACK: ${(err as Error).stack}`,
       );
       res.status(500).send({ error: 'Internal Server Error' });
     }
@@ -293,13 +300,7 @@ export class StorageController {
     }
 
     await Promise.all([
-      this.services.Folder.getByIdAndUserIds(
-        id,
-        [
-          behalfUser.id,
-          (req as AuthorizedRequest).user.id
-        ]
-      ),
+      this.services.Folder.getByIdAndUserIds(id, [behalfUser.id, (req as AuthorizedRequest).user.id]),
       this.services.Folder.getFolders(id, behalfUser.id, deleted),
       this.services.Files.getByFolderAndUserId(id, behalfUser.id, deleted),
     ])
@@ -421,6 +422,11 @@ export class StorageController {
       })
       .catch((err: Error) => {
         this.logger.error(`Error updating metadata from file ${fileId} : ${err}`);
+
+        if (err.message === FileWithNameAlreadyExistsError.message) {
+          res.status(409).send().end();
+        }
+
         res.status(500).send();
       });
   }

--- a/src/app/routes/storage.ts
+++ b/src/app/routes/storage.ts
@@ -13,6 +13,7 @@ import CONSTANTS from '../constants';
 import { LockNotAvaliableError } from '../services/errors/locks';
 import { ConnectionTimedOutError } from 'sequelize';
 import { FileWithNameAlreadyExistsError } from '../services/errors/FileWithNameAlreadyExistsError';
+import { FolderWithNameAlreadyExistsError } from '../services/errors/FolderWithNameAlreadyExistsError';
 
 type AuthorizedRequest = Request & { user: UserAttributes };
 interface Services {
@@ -286,6 +287,11 @@ export class StorageController {
       })
       .catch((err: Error) => {
         this.logger.error(`Error updating metadata from folder ${folderId}: ${err}`);
+
+        if (err.message === FolderWithNameAlreadyExistsError.message) {
+          res.status(409).send().end();
+        }
+
         res.status(500).send();
       });
   }

--- a/src/app/routes/storage.ts
+++ b/src/app/routes/storage.ts
@@ -288,7 +288,7 @@ export class StorageController {
       .catch((err: Error) => {
         this.logger.error(`Error updating metadata from folder ${folderId}: ${err}`);
 
-        if (err.message === FolderWithNameAlreadyExistsError.message) {
+        if (err instanceof FolderWithNameAlreadyExistsError) {
           res.status(409).send().end();
         }
 
@@ -429,7 +429,7 @@ export class StorageController {
       .catch((err: Error) => {
         this.logger.error(`Error updating metadata from file ${fileId} : ${err}`);
 
-        if (err.message === FileWithNameAlreadyExistsError.message) {
+        if (err instanceof FileWithNameAlreadyExistsError) {
           res.status(409).send().end();
         }
 

--- a/src/app/services/errors/FileWithNameAlreadyExistsError.ts
+++ b/src/app/services/errors/FileWithNameAlreadyExistsError.ts
@@ -1,6 +1,7 @@
 export class FileWithNameAlreadyExistsError extends Error {
-  static message = 'File with this name exists';
-  constructor() {
-    super(FileWithNameAlreadyExistsError.message);
+  constructor(message: string) {
+    super(message);
+
+    Object.setPrototypeOf(this, FileWithNameAlreadyExistsError.prototype);
   }
 }

--- a/src/app/services/errors/FileWithNameAlreadyExistsError.ts
+++ b/src/app/services/errors/FileWithNameAlreadyExistsError.ts
@@ -1,0 +1,6 @@
+export class FileWithNameAlreadyExistsError extends Error {
+  static message = 'File with this name exists';
+  constructor() {
+    super(FileWithNameAlreadyExistsError.message);
+  }
+}

--- a/src/app/services/errors/FolderWithNameAlreadyExistsError.ts
+++ b/src/app/services/errors/FolderWithNameAlreadyExistsError.ts
@@ -1,7 +1,7 @@
 export class FolderWithNameAlreadyExistsError extends Error {
-  static message = 'Folder with this name exists';
+  constructor(message: string) {
+    super(message);
 
-  constructor() {
-    super(FolderWithNameAlreadyExistsError.message);
+    Object.setPrototypeOf(this, FolderWithNameAlreadyExistsError.prototype);
   }
 }

--- a/src/app/services/errors/FolderWithNameAlreadyExistsError.ts
+++ b/src/app/services/errors/FolderWithNameAlreadyExistsError.ts
@@ -1,0 +1,7 @@
+export class FolderWithNameAlreadyExistsError extends Error {
+  static message = 'Folder with this name exists';
+
+  constructor() {
+    super(FolderWithNameAlreadyExistsError.message);
+  }
+}

--- a/src/app/services/files.js
+++ b/src/app/services/files.js
@@ -3,6 +3,7 @@ const async = require('async');
 const createHttpError = require('http-errors');
 const AesUtil = require('../../lib/AesUtil');
 const { v4 } = require('uuid');
+const { FileWithNameAlreadyExistsError } = require('./errors/FileWithNameAlreadyExistsError');
 
 // Filenames that contain "/", "\" or only spaces are invalid
 const invalidName = /[/\\]|^\s*$/;
@@ -210,7 +211,7 @@ module.exports = (Model, App) => {
         })
           .then((duplicateFile) => {
             if (duplicateFile) {
-              return next(Error('File with this name exists'));
+              return next(new FileWithNameAlreadyExistsError());
             }
             newMeta.name = cryptoFileName;
             newMeta.plain_name = metadata.itemName;

--- a/src/app/services/files.js
+++ b/src/app/services/files.js
@@ -211,7 +211,7 @@ module.exports = (Model, App) => {
         })
           .then((duplicateFile) => {
             if (duplicateFile) {
-              return next(new FileWithNameAlreadyExistsError());
+              return next(new FileWithNameAlreadyExistsError('File with this name exists'));
             }
             newMeta.name = cryptoFileName;
             newMeta.plain_name = metadata.itemName;

--- a/src/app/services/folder.js
+++ b/src/app/services/folder.js
@@ -7,6 +7,7 @@ const logger = require('../../lib/logger').default.getInstance();
 const { default: Redis } = require('../../config/initializers/redis');
 import { v4 } from 'uuid';
 import { LockNotAvaliableError } from './errors/locks';
+import { FolderWithNameAlreadyExistsError } from './errors/FolderWithNameAlreadyExistsError';
 
 const invalidName = /[\\/]|^\s*$/;
 
@@ -432,7 +433,7 @@ module.exports = (Model, App) => {
             })
             .then((isDuplicated) => {
               if (isDuplicated) {
-                return next(Error('Folder with this name exists'));
+                return next(new FolderWithNameAlreadyExistsError());
               }
               newMeta.name = cryptoFolderName;
               newMeta.plain_name = metadata.itemName;

--- a/src/app/services/folder.js
+++ b/src/app/services/folder.js
@@ -433,7 +433,7 @@ module.exports = (Model, App) => {
             })
             .then((isDuplicated) => {
               if (isDuplicated) {
-                return next(new FolderWithNameAlreadyExistsError());
+                return next(new FolderWithNameAlreadyExistsError('Folder with this name exists'));
               }
               newMeta.name = cryptoFolderName;
               newMeta.plain_name = metadata.itemName;


### PR DESCRIPTION
Changed the behavior of the following endpoints so when an update tries to rename an item with an existing name it returns a HTTP status code of `409` instead of `500`
- /storage/folder/{folderId}/meta
- /storage/file/{fileId}/meta