### PR TITLE
[PB-557] bug: file size from the drive-server comes as string

### DIFF
--- a/src/app/middleware/convert-size.ts
+++ b/src/app/middleware/convert-size.ts
@@ -1,0 +1,57 @@
+import { NextFunction, Request, Response } from 'express';
+
+export const convertSizeMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+  const client = req.headers['internxt-client'] as string;
+  const clientVersion = req.headers['internxt-version'] as string;
+  const userAgent = req.headers['user-agent'] ?? '';
+  // early exit meant to only apply this middleware for macOs client with older versions
+  if (
+    client !== 'drive-desktop' ||
+    !userAgent.toLowerCase().includes('mac') ||
+    compareVersion(clientVersion, '2.2.0.50') > 0
+  ) {
+    return next();
+  }
+  const oldSend = res.send;
+  res.send = function (data) {
+    const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+    let newData = data;
+    if (typeof parsedData === 'object') {
+      newData = { ...parsedData };
+      if ('size' in newData && typeof newData.size !== 'string') {
+        newData.size = newData.size.toString();
+      }
+    }
+
+    return oldSend.call(this, JSON.stringify(newData));
+  };
+
+  next();
+};
+
+const cleanAndSplitVersion = (version: string): number[] => {
+  return version
+    .replace(/[^0-9.]/g, '')
+    .split('.')
+    .map(Number);
+};
+
+export const compareVersion = (v1: string, v2: string): number => {
+  let v1Parts = cleanAndSplitVersion(v1);
+  let v2Parts = cleanAndSplitVersion(v2);
+
+  const maxLength = Math.max(v1Parts.length, v2Parts.length);
+
+  v1Parts = [...v1Parts, ...new Array(maxLength - v1Parts.length).fill(0)];
+  v2Parts = [...v2Parts, ...new Array(maxLength - v2Parts.length).fill(0)];
+
+  for (let i = 0; i < v1Parts.length; i++) {
+    if (v1Parts[i] > v2Parts[i]) {
+      return 1;
+    } else if (v1Parts[i] < v2Parts[i]) {
+      return -1;
+    }
+  }
+
+  return 0;
+};

--- a/src/app/models/file.ts
+++ b/src/app/models/file.ts
@@ -59,10 +59,7 @@ export default (database: Sequelize): FileModel => {
       },
       size: {
         type: DataTypes.BIGINT.UNSIGNED,
-      },
-      numericSize: {
-        type: DataTypes.VIRTUAL,
-        get(this: Model) {
+        get(): number {
           const size = this.getDataValue('size');
           return typeof size === 'number' ? size : parseInt(size);
         },

--- a/src/app/models/file.ts
+++ b/src/app/models/file.ts
@@ -58,6 +58,10 @@ export default (database: Sequelize): FileModel => {
       },
       size: {
         type: DataTypes.BIGINT.UNSIGNED,
+        get(): number {
+          const rawValue = this.getDataValue('size');
+          return typeof rawValue === 'number' ? rawValue : parseInt(rawValue);
+        }
       },
       bucket: {
         type: DataTypes.STRING(24),

--- a/src/app/models/file.ts
+++ b/src/app/models/file.ts
@@ -1,4 +1,4 @@
-import { Sequelize, ModelDefined, DataTypes } from 'sequelize';
+import { Sequelize, ModelDefined, DataTypes, Model } from 'sequelize';
 
 export enum FileStatus {
   EXISTS = 'EXISTS',
@@ -58,10 +58,13 @@ export default (database: Sequelize): FileModel => {
       },
       size: {
         type: DataTypes.BIGINT.UNSIGNED,
-        get(): number {
-          const rawValue = this.getDataValue('size');
-          return typeof rawValue === 'number' ? rawValue : parseInt(rawValue);
-        }
+      },
+      numericSize: {
+        type: DataTypes.VIRTUAL,
+        get(this: Model) {
+          const size = this.getDataValue('size');
+          return typeof size === 'number' ? size : parseInt(size);
+        },
       },
       bucket: {
         type: DataTypes.STRING(24),

--- a/src/app/routes/storage.ts
+++ b/src/app/routes/storage.ts
@@ -21,6 +21,7 @@ import {
 } from '../services/errors/FolderWithNameAlreadyExistsError';
 import * as resourceSharingMiddlewareBuilder from '../middleware/resource-sharing.middleware';
 import {validate } from 'uuid';
+import { convertSizeMiddleware } from '../middleware/convert-size';
 
 type AuthorizedRequest = Request & { user: UserAttributes };
 interface Services {
@@ -815,7 +816,8 @@ export default (router: Router, service: any) => {
     passportAuth,
     sharedAdapter,
     resourceSharingAdapter.UploadFile,
-    controller.createFile.bind(controller)
+    convertSizeMiddleware,
+    controller.createFile.bind(controller),
   );
   router.post('/storage/file/exists',
     passportAuth,


### PR DESCRIPTION
Added the virtual field `numericSize` in order to return the file size as a number instead of string. Whichever client needs the size as a number could simply use this property.