### PR TITLE
[_]: feat/return 403 instead of 401 when account is blocked

### DIFF
--- a/src/app/routes/auth.ts
+++ b/src/app/routes/auth.ts
@@ -125,7 +125,7 @@ export class AuthController {
     const loginAttemptsLimitReached = userData.errorLoginCount >= MAX_LOGIN_FAIL_ATTEMPTS;
 
     if (loginAttemptsLimitReached) {
-      throw createHttpError(401, 'Your account has been blocked for security reasons. Please reach out to us');
+      throw createHttpError(403, 'Your account has been blocked for security reasons. Please reach out to us');
     }
 
     const hashedPass = this.service.Crypt.decryptText(req.body.password);

--- a/tests/e2e/e2e-spec.ts
+++ b/tests/e2e/e2e-spec.ts
@@ -897,7 +897,7 @@ describe('E2E TEST', () => {
           .post('/api/access')
           .send({ ...TEST_USER_LOGIN_BODY });
 
-        expect(status).toBe(HttpStatus.UNAUTHORIZED);
+        expect(status).toBe(HttpStatus.FORBIDDEN);
         expect(body.error).toBe('Your account has been blocked for security reasons. Please reach out to us');
       });
     });


### PR DESCRIPTION
Consumer apps are not able to differentiate between wrong credentials and blocked account by just the http code.
In this PR we change the returned http code so they can take the necessary steps if an account is blocked.

According to RFC, we could also return 404, however, we are already including a message saying the user is blocked, so we have no reason to hide anything.

>    The 403 (Forbidden) status code indicates that the server understood
>    the request but refuses to authorize it.  A server that wishes to
>    make public why the request has been forbidden can describe that
>    reason in the response payload (if any).
> 
>    If authentication credentials were provided in the request, the
>    server considers them insufficient to grant access.  The client
>    SHOULD NOT automatically repeat the request with the same
>    credentials.  The client MAY repeat the request with new or different
>    credentials.  However, a request might be forbidden for reasons
>    unrelated to the credentials.
> 
>    An origin server that wishes to "hide" the current existence of a
>    forbidden target resource MAY instead respond with a status code of
>    404 (Not Found).

