### PR TITLE
[PB-267]: feat/small changes to add future iat to newTokens

### DIFF
--- a/src/app/middleware/passport.js
+++ b/src/app/middleware/passport.js
@@ -10,8 +10,15 @@ function Sign(data, secret, expires = false) {
   return token;
 }
 
-function SignWithOlderIAT(data, secret) {
-  return jwt.sign({ email: data, iat: getOlderIAT() }, secret, { expiresIn: '14d' });
+function SignWithFutureIAT(data, secret) {
+  return jwt.sign({ email: data, iat: getFutureIAT() }, secret, { expiresIn: '14d' });
+}
+
+function SignNewTokenWithFutureIAT(data, secret, expires = false) {
+  const futureIat = getFutureIAT();
+  return expires
+    ? jwt.sign(getNewTokenPayload(data, futureIat), secret, { expiresIn: '14d' })
+    : jwt.sign(getNewTokenPayload(data, futureIat), secret);
 }
 
 function SignNewToken(data, secret, expires = false) {
@@ -21,7 +28,7 @@ function SignNewToken(data, secret, expires = false) {
   return token;
 }
 
-function getNewTokenPayload(userData) {
+function getNewTokenPayload(userData, customIat) {
   return {
     payload: {
       uuid: userData.uuid,
@@ -34,8 +41,8 @@ function getNewTokenPayload(userData) {
         user: userData.bridgeUser,
         pass: userData.userId,
       },
-      iat: getDefaultIAT(),
     },
+    iat: customIat ?? getDefaultIAT(),
   };
 }
 
@@ -43,7 +50,7 @@ function getDefaultIAT() {
   return Math.floor(Date.now() / 1000);
 }
 
-function getOlderIAT() {
+function getFutureIAT() {
   return Math.floor(Date.now() / 1000) + 60;
 }
 
@@ -51,5 +58,6 @@ module.exports = {
   passportAuth,
   Sign,
   SignNewToken,
-  SignWithOlderIAT,
+  SignWithFutureIAT,
+  SignNewTokenWithFutureIAT,
 };

--- a/src/app/routes/user.js
+++ b/src/app/routes/user.js
@@ -1,6 +1,6 @@
 const openpgp = require('openpgp');
 const createHttpError = require('http-errors');
-const { passportAuth, Sign, SignNewToken, SignWithOlderIAT } = require('../middleware/passport');
+const { passportAuth, Sign, SignWithFutureIAT, SignNewTokenWithFutureIAT } = require('../middleware/passport');
 const Logger = require('../../lib/logger').default;
 const AnalyticsService = require('../../lib/analytics/AnalyticsService');
 const { default: uploadAvatar } = require('../middleware/upload-avatar');
@@ -16,8 +16,8 @@ module.exports = (Router, Service, App) => {
 
     Service.User.UpdatePasswordMnemonic(req.user, currentPassword, newPassword, newSalt, mnemonic, privateKey)
       .then(() => {
-        const token = SignWithOlderIAT(req.user.email, App.config.get('secrets').JWT);
-        const newToken = SignNewToken(req.user, App.config.get('secrets').JWT);
+        const token = SignWithFutureIAT(req.user.email, App.config.get('secrets').JWT);
+        const newToken = SignNewTokenWithFutureIAT(req.user, App.config.get('secrets').JWT);
         res.status(200).send({ token, newToken });
       })
       .catch((err) => {
@@ -158,10 +158,10 @@ module.exports = (Router, Service, App) => {
       res.status(200).send({ token, user });
     } catch (err) {
       logger.error(
-        'Update user error %s: %s. STACK %s. BODY %s', 
-        req.user.email, 
-        err.message, 
-        err.stack || 'NO STACK', 
+        'Update user error %s: %s. STACK %s. BODY %s',
+        req.user.email,
+        err.message,
+        err.stack || 'NO STACK',
         req.body
       );
       res.status(500).send({ error: 'Internal Server error' });


### PR DESCRIPTION
1. Moved iat out of `payload` for newTokens to align with drive-server-wip. 
2. Changed older to "future" just to understand better that the token is some time ahead.
3. Added iat to returned  newToken when password changes. 