### PR TITLE
[_]: Fix/Sign token using email

### DIFF
--- a/src/app/middleware/passport.js
+++ b/src/app/middleware/passport.js
@@ -6,7 +6,7 @@ const passportAuth = passport.authenticate('jwt', { session: false });
 function Sign(data, secret, expires = false) {
   const token = expires ?
     jwt.sign({ email: data, iat: getDefaultIAT() }, secret, { expiresIn: '14d' }) :
-    jwt.sign(Object.assign(data, { iat: getDefaultIAT() }), secret);
+    jwt.sign({ email: data, iat: getDefaultIAT() }, secret);
   return token;
 }
 

--- a/tests/e2e/e2e-spec.ts
+++ b/tests/e2e/e2e-spec.ts
@@ -98,7 +98,7 @@ describe('E2E TEST', () => {
 
         userId = user.dataValues.id;
         rootFolderId = user.dataValues.root_folder_id;
-        token = Sign({ email }, server.config.get('secrets').JWT);
+        token = Sign(email, server.config.get('secrets').JWT);
       } catch (err: any) {
         // eslint-disable-next-line no-console
         console.error('Error setting up storage e2e tests: %s', err.message);
@@ -943,7 +943,7 @@ describe('E2E TEST', () => {
 
         userId = user.dataValues.id;
         rootFolderId = user.dataValues.root_folder_id;
-        token = Sign({ email }, server.config.get('secrets').JWT);
+        token = Sign(email, server.config.get('secrets').JWT);
       } catch (err: any) {
         // eslint-disable-next-line no-console
         console.error('Error setting up storage e2e tests: %s', err.message);


### PR DESCRIPTION
- Fixes wrong sign property from token, currently used only at the endpoint '/users/refresh'  from desktop