### PR TITLE
[IN-19]: ci-add-latest-tag-to-docker-image

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -29,7 +29,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/drive-server:${{ github.sha }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/drive-server:${{ github.sha }},${{ secrets.DOCKERHUB_USERNAME }}/drive-server:latest
   deploy:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Add latest tag to docker image

The idea is to have all services tagged with `latest` so we can easily pull the latest version of the image without the commit sha.

