### PR TITLE
[PB-1428]: feat/limit-upload-file-size

### DIFF
--- a/src/app/middleware/feature-limits.middleware.ts
+++ b/src/app/middleware/feature-limits.middleware.ts
@@ -1,0 +1,64 @@
+import { Request, Response, NextFunction } from 'express';
+import { AuthorizedUser } from '../routes/types';
+
+type User = AuthorizedUser['user'];
+type Middleware = (req: Request & { behalfUser?: User }, res: Response, next: NextFunction) => Promise<void>;
+type DataSource = { fieldName: string; sourceKey: string };
+type BuilderArgs = {
+  limitLabel: string;
+  dataSources: DataSource[];
+};
+
+const LimitLabels = {
+  MaxFileUploadSize: 'max-file-upload-size',
+};
+
+const build = (Service: {
+  FeatureLimits: {
+    shouldLimitBeEnforced: (user: User, limitLabel: string, data: any) => Promise<boolean>;
+  };
+}) => {
+  const mdBuilder = ({ limitLabel, dataSources }: BuilderArgs) =>
+    (async (req, res, next) => {
+      try {
+        const user = (req as any).behalfUser || (req as AuthorizedUser).user;
+
+        if (!user) {
+          return next();
+        }
+
+        const extractedData = extractDataFromRequest(req, dataSources);
+        const shouldLimitBeEnforced = await Service.FeatureLimits.shouldLimitBeEnforced(
+          user,
+          limitLabel,
+          extractedData,
+        );
+
+        if (shouldLimitBeEnforced) {
+          return res.status(402).send('You reached the limit for your tier!');
+        }
+
+        next();
+      } catch (err) {
+        next(err);
+      }
+    }) as Middleware;
+
+  return {
+    UploadFile: mdBuilder({
+      limitLabel: LimitLabels.MaxFileUploadSize,
+      dataSources: [{ sourceKey: 'body', fieldName: 'file' }],
+    }),
+  };
+};
+
+const extractDataFromRequest = (request: any, dataSources: DataSource[]) => {
+  const extractedData = {} as any;
+  for (const { sourceKey, fieldName } of dataSources) {
+    const value = request[sourceKey][fieldName];
+    extractedData[fieldName] = value;
+  }
+  return extractedData;
+};
+
+export { build, LimitLabels };

--- a/src/app/middleware/feature-limits.middleware.ts
+++ b/src/app/middleware/feature-limits.middleware.ts
@@ -44,7 +44,7 @@ const build = (Service: {
           }
         } catch (err) {
           if (err instanceof MissingValuesForFeatureLimit) {
-            return res.status(400).send('You reached the limit for your tier!');
+            return res.status(400).send('You have missing values needed to validate users limit!');
           }
 
           if (err instanceof NoLimitFoundForUserTierAndLabel) {

--- a/src/app/middleware/feature-limits.middleware.ts
+++ b/src/app/middleware/feature-limits.middleware.ts
@@ -27,7 +27,7 @@ const build = (Service: {
       try {
         const user = (req as any).behalfUser || (req as AuthorizedUser).user;
 
-        if (!user) {
+        if (!user || !user.tierId) {
           return next();
         }
 

--- a/src/app/middleware/feature-limits.middleware.ts
+++ b/src/app/middleware/feature-limits.middleware.ts
@@ -44,7 +44,7 @@ const build = (Service: {
           }
         } catch (err) {
           if (err instanceof MissingValuesForFeatureLimit) {
-            return res.status(400).send('You have missing values needed to validate users limit!');
+            return res.status(400).send(err.message);
           }
 
           if (err instanceof NoLimitFoundForUserTierAndLabel) {
@@ -74,6 +74,9 @@ const extractDataFromRequest = (request: any, dataSources: DataSource[]) => {
   const extractedData = {} as any;
   for (const { sourceKey, fieldName } of dataSources) {
     const value = request[sourceKey][fieldName];
+    if (value === null || value === undefined) {
+      throw new MissingValuesForFeatureLimit(`Missing required value to check user limits, ${fieldName} is missing`);
+    }
     extractedData[fieldName] = value;
   }
   return extractedData;

--- a/src/app/models/index.ts
+++ b/src/app/models/index.ts
@@ -176,7 +176,6 @@ export default (database: Sequelize) => {
 
   Limit.belongsToMany(Tier, {
     through: TierLimit,
-    as: 'tiers',
   });
 
   return {

--- a/src/app/routes/storage.ts
+++ b/src/app/routes/storage.ts
@@ -21,6 +21,7 @@ import {
   FolderWithNameAlreadyExistsError
 } from '../services/errors/FolderWithNameAlreadyExistsError';
 import * as resourceSharingMiddlewareBuilder from '../middleware/resource-sharing.middleware';
+import * as featureLimitsMiddlewareBuilder from '../middleware/feature-limits.middleware';
 import {validate } from 'uuid';
 
 type AuthorizedRequest = Request & { user: UserAttributes };
@@ -811,12 +812,14 @@ export default (router: Router, service: any) => {
   const sharedAdapter = sharedMiddlewareBuilder.build(service);
   const teamsAdapter = teamsMiddlewareBuilder.build(service);
   const resourceSharingAdapter = resourceSharingMiddlewareBuilder.build(service);
+  const featureLimitsAdapter = featureLimitsMiddlewareBuilder.build(service);
   const controller = new StorageController(service, Logger);
 
   router.post('/storage/file',
     passportAuth,
     sharedAdapter,
     resourceSharingAdapter.UploadFile,
+    featureLimitsAdapter.UploadFile,
     controller.createFile.bind(controller)
   );
   router.post('/storage/file/exists',

--- a/src/app/services/errors/FeatureLimitsErrors.ts
+++ b/src/app/services/errors/FeatureLimitsErrors.ts
@@ -5,3 +5,11 @@ export class NoLimitFoundForUserTierAndLabel extends Error {
     Object.setPrototypeOf(this, NoLimitFoundForUserTierAndLabel.prototype);
   }
 }
+
+export class MissingValuesForFeatureLimit extends Error {
+  constructor(message: string) {
+    super(message);
+
+    Object.setPrototypeOf(this, MissingValuesForFeatureLimit.prototype);
+  }
+}

--- a/src/app/services/errors/FeatureLimitsErrors.ts
+++ b/src/app/services/errors/FeatureLimitsErrors.ts
@@ -1,0 +1,7 @@
+export class NoLimitFoundForUserTierAndLabel extends Error {
+  constructor(message: string) {
+    super(message);
+
+    Object.setPrototypeOf(this, NoLimitFoundForUserTierAndLabel.prototype);
+  }
+}

--- a/src/app/services/featureLimit.js
+++ b/src/app/services/featureLimit.js
@@ -59,7 +59,7 @@ module.exports = (Model, App) => {
       case LimitLabels.MaxFileUploadSize:
         return isMaxFileSizeLimitSurprassed({ limit, data });
       default:
-        return null;
+        return false;
     }
   };
 

--- a/src/app/services/featureLimit.js
+++ b/src/app/services/featureLimit.js
@@ -58,13 +58,13 @@ module.exports = (Model, App) => {
   const checkCounterLimit = (user, limit, data) => {
     switch (limit.label) {
       case LimitLabels.MaxFileUploadSize:
-        return isMaxFileSizeLimitSurprassed({ limit, data });
+        return isMaxFileSizeLimitSurpassed({ limit, data });
       default:
         return false;
     }
   };
 
-  const isMaxFileSizeLimitSurprassed = async ({ limit, data }) => {
+  const isMaxFileSizeLimitSurpassed = async ({ limit, data }) => {
     const {
       file: { size },
     } = data;

--- a/src/app/services/featureLimit.js
+++ b/src/app/services/featureLimit.js
@@ -1,6 +1,7 @@
 const { INDIVIDUAL_FREE_TIER_PLAN_ID } = require('../constants');
 const { LimitLabels } = require('../middleware/feature-limits.middleware');
 const { NoLimitFoundForUserTierAndLabel } = require('./errors/FeatureLimitsErrors');
+const { INDIVIDUAL_FREE_TIER_PLAN_ID } = require('../constants');
 
 const LimitTypes = {
   Counter: 'counter',
@@ -75,5 +76,6 @@ module.exports = (Model, App) => {
     getTierByPlanId,
     getIndividualFreeTier,
     shouldLimitBeEnforced,
+    getIndividualFreeTier,
   };
 };

--- a/src/app/services/featureLimit.js
+++ b/src/app/services/featureLimit.js
@@ -68,7 +68,7 @@ module.exports = (Model, App) => {
     const {
       file: { size },
     } = data;
-    return Number(limit.value) < size / 1024 / 1024 / 1024;
+    return Number(limit.value) < size;
   };
 
   return {

--- a/src/app/services/featureLimit.js
+++ b/src/app/services/featureLimit.js
@@ -1,4 +1,11 @@
 const { INDIVIDUAL_FREE_TIER_PLAN_ID } = require('../constants');
+const { LimitLabels } = require('../middleware/feature-limits.middleware');
+const { NoLimitFoundForUserTierAndLabel } = require('./errors/FeatureLimitsErrors');
+
+const LimitTypes = {
+  Counter: 'counter',
+  Boolean: 'boolean',
+};
 
 module.exports = (Model, App) => {
   const getTierByPlanId = async (planId) => {
@@ -12,9 +19,61 @@ module.exports = (Model, App) => {
     return getTierByPlanId(INDIVIDUAL_FREE_TIER_PLAN_ID);
   };
 
+  const findLimitByLabelAndTier = async (tierId, label) => {
+    return Model.limits.findOne({
+      where: {
+        label,
+      },
+      include: [
+        {
+          model: Model.tiers,
+          where: {
+            id: tierId,
+          },
+        },
+      ],
+    });
+  };
+
+  const isBooleanLimitNotAvailable = (limit) => {
+    return limit.type === LimitTypes.Boolean && limit.value !== 'true';
+  };
+
+  const shouldLimitBeEnforced = async (user, limitLabel, data) => {
+    const limit = await findLimitByLabelAndTier(user.tierId, limitLabel);
+
+    if (!limit) {
+      throw new NoLimitFoundForUserTierAndLabel('No limit found for this user tier and label!');
+    }
+    if (limit.type === LimitTypes.Boolean) {
+      return isBooleanLimitNotAvailable(limit);
+    }
+
+    const isLimitSuprassed = await checkCounterLimit(user, limit, data);
+
+    return isLimitSuprassed;
+  };
+
+  const checkCounterLimit = (user, limit, data) => {
+    switch (limit.label) {
+      case LimitLabels.MaxFileUploadSize:
+        return isMaxFileSizeLimitSurprassed({ limit, data });
+      default:
+        return null;
+    }
+  };
+
+  const isMaxFileSizeLimitSurprassed = async ({ limit, data }) => {
+    const {
+      file: { size },
+    } = data;
+    return Number(limit.value) < size / 1024 / 1024 / 1024;
+  };
+
   return {
     Name: 'FeatureLimits',
     getTierByPlanId,
     getIndividualFreeTier,
+    shouldLimitBeEnforced,
   };
 };


### PR DESCRIPTION
This is currently being tested on the test environment along with payments.

The current flow for the frontend is:
1. it uploads the file to the network
2. it asks the backend to store the file location, data, name, etc in the database.

If we enforce the limits with this flow, then users are going to upload files that  they do not know if it is between their current tier o not. Therefore, it is essential to enable a new endpoints along with the limit enforcement.

What it is included in this PR?

1. Middleware to enforce file upload size limit when a user tries to create a file.
2. A new endpoint for the frontend to consume so they can know beforehand if a file size is valid or not. 
3. Gateway update tier should apply free tier if for some reason, payments fail to send a correct planId.

Note: Middleware enforcement is bypassed if user.tierId is empty, regarding the new endpoint, it throws a 404, so the frontend is going to be able to know that this user does not have a limit set yet.