### PR TITLE
[PB-1921]: fix/change-network-request-to-update-bucket-limit

### DIFF
--- a/src/app/routes/gateway.js
+++ b/src/app/routes/gateway.js
@@ -37,6 +37,7 @@ module.exports = (Router, Service) => {
         // eslint-disable-next-line consistent-return
       })
       .then(() => {
+        // TODO: updateBucketLimit is malfunctioning and no longer needed
         if (user.backupsBucket) {
           return Service.Inxt.updateBucketLimit(user.backupsBucket, bucketLimit);
         }

--- a/src/app/services/backups.js
+++ b/src/app/services/backups.js
@@ -70,23 +70,14 @@ module.exports = (Model, App) => {
   };
 
   const activate = async (userData) => {
-    const { Inxt, User, Plan } = App.services;
+    const { Inxt, User } = App.services;
     let { backupsBucket } = await User.FindUserObjByEmail(userData.email);
-
-    const plan = await Plan.getByUserId(userData.id);
-    let limit = -1;
 
     if (!backupsBucket) {
       // TODO: Remove mnemonic from here
       backupsBucket = (await Inxt.CreateBucket(userData.email, userData.userId, userData.mnemonic)).id;
       await Model.users.update({ backupsBucket }, { where: { username: { [Op.eq]: userData.email } } });
     }
-
-    if (plan && plan.type === 'one_time') {
-      limit = 100 * 1024 * 1024 * 1024;
-    }
-
-    return Inxt.updateBucketLimit(backupsBucket, limit);
   };
 
   const createDeviceAsFolder = async (userData, deviceName) => {

--- a/src/app/services/inxt.js
+++ b/src/app/services/inxt.js
@@ -120,6 +120,7 @@ module.exports = (Model, App) => {
       });
   };
 
+  // TODO: updateBucketLimit is malfunctioning and no longer needed
   const updateBucketLimit = (bucketId, limit) => {
     const { GATEWAY_USER, GATEWAY_PASS } = process.env;
 


### PR DESCRIPTION
`updateBucketLimit` was using /gateway/bucket/:id to increase the bucket size limit, nevertheless, that endpoint was deleted 2 years ago in the following PR https://github.com/internxt/bridge/pull/26/files#diff-3fa217d4848a564301c4d296c2f620cd33b296b7c712a1280b90e2af47fbb961L98

Proposed solution is to delete the call to `updateBucketLimit` because is no longer needed.

JIRA: https://inxt.atlassian.net/browse/PB-1921