### PR TITLE
[_]:(fix) Detect if backups device exists and is not deleted

### DIFF
--- a/src/app/services/backups.js
+++ b/src/app/services/backups.js
@@ -95,6 +95,8 @@ module.exports = (Model, App) => {
       where: {
         bucket: { [Op.eq]: backupsBucket },
         name: { [Op.eq]: encryptedFolderName },
+        deleted: { [Op.eq]: false},
+        removed: { [Op.eq]: false}
       },
     });
 


### PR DESCRIPTION
Right now we are detecting if a backups device already exists just by matching the name and bucket, but a device could exists with those matches, and being already deleted. So we need to match an already existing backup devices by this criteria:

- Bucket matches
- Name matches
- Is not deleted
- Is not removed