### PR TITLE
[_]: feat/reduce-latency-on-user-refresh

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -22,6 +22,7 @@ MAGIC_SALT=38dce0391b49efba88dbc8c39ebf868f0267eb110bb0012ab27dc52a528d61b1d1ed9
 NODE_ENV=development
 NOTIFICATIONS_URL=http://notifications:4000
 NOTIFICATIONS_API_KEY=secret
+PAYMENTS_SERVER_URL=http://payments-server:8002
 RDS_DBNAME=xCloud
 RDS_HOSTNAME=drive-database
 RDS_PASSWORD=example

--- a/src/app/routes/auth.ts
+++ b/src/app/routes/auth.ts
@@ -194,8 +194,7 @@ export class AuthController {
       sharedWorkspace: userData.sharedWorkspace,
       appSumoDetails: null,
       hasReferralsProgram: await this.service.UsersReferrals.hasReferralsProgram(
-        userData.id,
-        userData.email,
+        userData,
         userData.bridgeUser,
         userData.userId,
       ),

--- a/src/app/routes/routes.ts
+++ b/src/app/routes/routes.ts
@@ -97,8 +97,7 @@ export default (router: Router, service: any, App: any): Router => {
       sharedWorkspace: userData.sharedWorkspace,
       appSumoDetails: null,
       hasReferralsProgram: await service.UsersReferrals.hasReferralsProgram(
-        userData.id,
-        userData.email,
+        userData,
         userData.bridgeUser,
         userData.userId,
       ),

--- a/src/app/services/plan.js
+++ b/src/app/services/plan.js
@@ -95,12 +95,12 @@ module.exports = (Model, App) => {
     return result;
   };
 
-  const hasBeenIndividualSubscribedAnyTime = async (userEmail, networkUser, networkPass) => {
-    const subscriptionPlans = (await stripeService.getUserSubscriptionPlans(userEmail)).filter((plan) => !plan.isTeam);
+  const hasBeenIndividualSubscribedAnyTime = async (user, networkUser, networkPass) => {
+    const userExistsInPayments = await stripeService.userExistsInPayments(user);
     const { maxSpaceBytes } = await limitService.getLimit(networkUser, networkPass);
     const isLifetime = maxSpaceBytes > MAX_FREE_PLAN_BYTES;
 
-    return subscriptionPlans.length > 0 || isLifetime;
+    return userExistsInPayments || isLifetime;
   };
 
   const isValid = (plan) => {

--- a/src/app/services/usersReferrals.js
+++ b/src/app/services/usersReferrals.js
@@ -65,12 +65,12 @@ module.exports = (Model, App) => {
     }));
   };
 
-  const hasReferralsProgram = async (userId, userEmail, networkUser, networkPassword) => {
-    const appSumoDetails = await App.services.AppSumo.GetDetails(userId).catch(() => null);
+  const hasReferralsProgram = async (user, networkUser, networkPassword) => {
+    const appSumoDetails = await App.services.AppSumo.GetDetails(user.id).catch(() => null);
 
     return (
       !appSumoDetails &&
-      !(await App.services.Plan.hasBeenIndividualSubscribedAnyTime(userEmail, networkUser, networkPassword))
+      !(await App.services.Plan.hasBeenIndividualSubscribedAnyTime(user, networkUser, networkPassword))
     );
   };
 
@@ -113,7 +113,7 @@ module.exports = (Model, App) => {
       return;
     }
 
-    const userHasReferralsProgram = await hasReferralsProgram(userId, user.email, user.bridgeUser, user.userId);
+    const userHasReferralsProgram = await hasReferralsProgram(user, user.bridgeUser, user.userId);
     if (!userHasReferralsProgram) {
       throw new ReferralsNotAvailableError();
     }


### PR DESCRIPTION
These changes aim to reduce latency on user refresh. The 57% of the time spent on this endpoint this last month has been due to the Stripe external API call, therefore, the change tries to avoid Stripe while guaranteeing consistency on the check done during the refresh that asks Stripe: if a user is a paid one or not.

A new environment variable has been set: `PAYMENTS_SERVER_URL`