### PR TITLE
[_]: fix: update APN JWT expiration check to use milliseconds

### DIFF
--- a/src/config/initializers/apn.ts
+++ b/src/config/initializers/apn.ts
@@ -55,7 +55,7 @@ export default class Apn {
     if (!process.env.APN_SECRET || !process.env.APN_KEY_ID || !process.env.APN_TEAM_ID) {
       throw new Error('Undefined APN env variables, necessary for JWT generation');
     }
-    if (this.jwt && Date.now() - this.jwtGeneratedAt < 3600) {
+    if (this.jwt && Date.now() - this.jwtGeneratedAt < 3600 * 1000) {
       return this.jwt;
     }
 
@@ -142,7 +142,6 @@ export default class Apn {
 
       let statusCode = 0;
       let data = '';
-
     });
   }
 }


### PR DESCRIPTION
APN is rejecting requests with `TooManyProviderTokenUpdates`, meaning the JWT is being updated too often. The problem was in the JWT generation logic, where milliseconds were compared with seconds.