### PR TITLE
[_]: fix/correctly format logs in prod

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -13,6 +13,7 @@ const winstonProdOptions: winston.LoggerOptions = {
   handleExceptions: true,
   format: combine(
     timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+    splat(),
     printf((info) => {
       return JSON.stringify({
         hostname: serverHostname,


### PR DESCRIPTION
Add splat() to winston config in order to correctly formar logs in production.