### PR TITLE
[PB-3870]: feat/plainName with the decrypted name for devicesAsFolder endpoint

### DIFF
--- a/src/app/services/backups.js
+++ b/src/app/services/backups.js
@@ -182,6 +182,7 @@ module.exports = (Model, App) => {
           name: backupName,
           hasBackups: !(await isDeviceAsFolderEmpty(folder)),
           lastBackupAt: folder.updatedAt,
+          plainName: App.services.Crypt.decryptName(backupName, folder.bucket),
         };
       }),
     );


### PR DESCRIPTION
This PR returns the decrypted name using the painName property. This way, we avoid decrypting the device name on the client side.